### PR TITLE
Update/group props

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -108,6 +108,8 @@ function identify(payload, fn) {
  * @param {Object} payload
  * @param {Function} fn
  */
+
+ // TODO: Ensure there is a userId here. Segment API does not require one, Amplitude does.
  function group(payload, fn) {
   var self = this;
   return this

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,7 +109,6 @@ function identify(payload, fn) {
  * @param {Function} fn
  */
 
- // TODO: Ensure there is a userId here. Segment API does not require one, Amplitude does.
  function group(payload, fn) {
   var self = this;
   return this

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -291,7 +291,7 @@ function traits(traits){
  * @param {Group} group
  * @return {Object} payload
  */
-// groupType is a string and groupName can be either a string or an // array of strings to indicate a user being in multiple groups (for // example, if Joe is in 'orgId' '10' and '16', then the groupName // would be '[10, 16]').
+
 exports.group = function(group){
   var groupId = group.groupId();
   if (!groupId) return;
@@ -299,10 +299,10 @@ exports.group = function(group){
     user_id: group.userId(),
     device_id: deviceId(group),
     time: group.timestamp().getTime()
-  }
-  console.log(payload);
+  };
   var groupName = group.options(this.name).groupName;
-  // If groupName is undefined, proceed as we have been
+  
+  // If groupName is undefined, proceed as we have been.
   if (!groupName) {
     payload.groups = { '[Segment] Group': groupId };
     payload.user_properties = { '[Segment] Group': groupId };

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -291,20 +291,26 @@ function traits(traits){
  * @param {Group} group
  * @return {Object} payload
  */
-
+// groupType is a string and groupName can be either a string or an // array of strings to indicate a user being in multiple groups (for // example, if Joe is in 'orgId' '10' and '16', then the groupName // would be '[10, 16]').
 exports.group = function(group){
   var groupId = group.groupId();
   if (!groupId) return;
   var payload = {
     user_id: group.userId(),
     device_id: deviceId(group),
-    time: group.timestamp().getTime(),
-    groups: {
-      '[Segment] Group': groupId
-    },
-    user_properties: {
-      '[Segment] Group': groupId
-    }
+    time: group.timestamp().getTime()
+  }
+  console.log(payload);
+  var groupName = group.options(this.name).groupName;
+  // If groupName is undefined, proceed as we have been
+  if (!groupName) {
+    payload.groups = { '[Segment] Group': groupId };
+    payload.user_properties = { '[Segment] Group': groupId };
+  } else {
+    payload.groups = {
+      company_id: groupId,
+      company_name: groupName
+    };
   }
   return payload;
 };

--- a/test/fixtures/group-with-groupName.json
+++ b/test/fixtures/group-with-groupName.json
@@ -2,18 +2,9 @@
   "input": {
     "type": "group",
     "groupId": "sports",
-    "userId": "ccnixon",
+    "userId": "group-user",
     "event": "my-event",
     "timestamp": "2014",
-    "properties": {
-      "revenue": 19.99,
-      "property": true
-    },
-    "traits": {
-      "address": {
-        "country": "some-country"
-      }
-    },
     "integrations": {
       "Amplitude": {
         "groupName": ["baseball", "football"]
@@ -21,7 +12,7 @@
     }
   },
   "output": {
-    "user_id": "ccnixon",
+    "user_id": "group-user",
     "time": 1388534400000,
     "groups": {
       "company_id": "sports",

--- a/test/fixtures/group-with-groupName.json
+++ b/test/fixtures/group-with-groupName.json
@@ -1,0 +1,32 @@
+{
+  "input": {
+    "type": "group",
+    "groupId": "sports",
+    "userId": "ccnixon",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "property": true
+    },
+    "traits": {
+      "address": {
+        "country": "some-country"
+      }
+    },
+    "integrations": {
+      "Amplitude": {
+        "groupName": ["baseball", "football"]
+      }
+    }
+  },
+  "output": {
+    "user_id": "ccnixon",
+    "time": 1388534400000,
+    "groups": {
+      "company_id": "sports",
+      "company_name": ["baseball", "football"]
+    }
+  }
+}
+

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ describe('Amplitude', function(){
 
   beforeEach(function(){
     settings = {
-      apiKey: '4e3df7bd447077d4cb94eecc102ea185',
+      apiKey: 'ad3c426eb736d7442a65da8174bc1b1b',
       trackAllPages: true,
       trackCategorizedPages: false,
       trackNamedPages: false,
@@ -589,11 +589,9 @@ describe('Amplitude', function(){
         .end(done);
     });
 
-    it.only('should map a user to multiple groups', function(done){
+    it('should map a user to multiple groups', function(done){
       var json = test.fixture('group-with-groupName');
-      var time = Date.now();
-      json.input.timestamp = time;
-      json.output.time = time;
+
       test
         .group(json.input)
         .sends('api_key=' + settings.apiKey + '&identification=' + encode(JSON.stringify(json.output)))

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ describe('Amplitude', function(){
 
   beforeEach(function(){
     settings = {
-      apiKey: 'ad3c426eb736d7442a65da8174bc1b1b',
+      apiKey: '4e3df7bd447077d4cb94eecc102ea185',
       trackAllPages: true,
       trackCategorizedPages: false,
       trackNamedPages: false,
@@ -582,6 +582,18 @@ describe('Amplitude', function(){
   describe('.group()', function(){
     it('should map group calls correctly', function(done){
       var json = test.fixture('group-basic');
+      test
+        .group(json.input)
+        .sends('api_key=' + settings.apiKey + '&identification=' + encode(JSON.stringify(json.output)))
+        .expects(200)
+        .end(done);
+    });
+
+    it.only('should map a user to multiple groups', function(done){
+      var json = test.fixture('group-with-groupName');
+      var time = Date.now();
+      json.input.timestamp = time;
+      json.output.time = time;
       test
         .group(json.input)
         .sends('api_key=' + settings.apiKey + '&identification=' + encode(JSON.stringify(json.output)))


### PR DESCRIPTION
Allow user to leverage amplitude's native `groups` functionality: https://amplitude.zendesk.com/hc/en-us/articles/115001361248#setting-user-groups

Jira: https://segment.atlassian.net/browse/EPD-2771

`group` method will now check to see if a property called `groupName` has been passed as an integration specific option. If so, it will map the groupId and the groupName(s) to the correct property names in the payload to amplitude.